### PR TITLE
Default to JSONSL_STATE_GENERIC mode without compile-time complaint.

### DIFF
--- a/jsonsl.h
+++ b/jsonsl.h
@@ -48,8 +48,6 @@ typedef int ssize_t;
 
 
 #if (!defined(JSONSL_STATE_GENERIC)) && (!defined(JSONSL_STATE_USER_FIELDS))
-#warning "JSONSL_STATE_USER_FIELDS not defined. Define this for extra structure fields"
-#warning "or define JSONSL_STATE_GENERIC"
 #define JSONSL_STATE_GENERIC
 #endif /* !defined JSONSL_STATE_GENERIC */
 


### PR DESCRIPTION
The desire is to compile and link jsonsl without the need for -DJSONSL_STATE_GENERIC scattered around the build system.

---

The jsonsl library is being used by a library that wants to be built conveniently for a variety of platforms, and linked statically or dynamically.  For convenience, JSONSL_STATE_USER_FIELDS ought to be opt-in, with JSONSL_STATE_GENERIC as default, without compile-time warnings.
- Nigel
