### PR TITLE
Partial undo of previous Windows #ifdef logic for int8_t etc.

### DIFF
--- a/jsonsl.h
+++ b/jsonsl.h
@@ -29,7 +29,7 @@ typedef unsigned char jsonsl_uchar_t;
 #endif /* JSONSL_USE_WCHAR */
 
 /* Stolen from http-parser.h, and possibly others */
-#if defined(_WIN32) && !defined(__MINGW32__) 
+#if defined(_WIN32) && !defined(__MINGW32__) && (!defined(_MSC_VER) || _MSC_VER<1600)
 typedef __int8 int8_t;
 typedef unsigned __int8 uint8_t;
 typedef __int16 int16_t;


### PR DESCRIPTION
If stdint.h is included ahead of jsonsl.h by VC10 compiler, int8_t is already declared.

---

Oops, my bad.  I came across this build issue just today.
- Nigel
