### PR TITLE
Adds MISSING_COMMA error

### DIFF
--- a/jsonsl.c
+++ b/jsonsl.c
@@ -529,6 +529,9 @@ jsonsl_feed(jsonsl_t jsn, const jsonsl_char_t *bytes, size_t nbytes)
                 CONTINUE_NEXT_CHAR();
 
             case JSONSL_T_LIST:
+                if (jsn->expecting == ',') {
+                    INVOKE_ERROR(MISSING_COMMA);
+                }
                 state->nelem++;
                 STACK_PUSH;
                 state->type = JSONSL_T_STRING;
@@ -661,6 +664,9 @@ jsonsl_feed(jsonsl_t jsn, const jsonsl_char_t *bytes, size_t nbytes)
              * we are not doing full numerical/value decoding anyway (but only hinting),
              * we only check upon entry.
              */
+            if (jsn->expecting == ',') {
+                INVOKE_ERROR(MISSING_COMMA);
+            }
             if (state->type != JSONSL_T_SPECIAL) {
                 int special_flags = extract_special(CUR_CHAR);
                 if (!special_flags) {

--- a/jsonsl.h
+++ b/jsonsl.h
@@ -202,6 +202,8 @@ typedef enum {
     X(STRAY_TOKEN) \
 /* We were expecting a token before this one */ \
     X(MISSING_TOKEN) \
+/* We were expecting a comma befoe this token */ \
+    X(MISSING_COMMA) \
 /* Cannot insert because the container is not ready */ \
     X(CANT_INSERT) \
 /* Found a '\' outside a string */ \


### PR DESCRIPTION
Fixes #12. Prevents JSON documents containing lists of strings/specials w/o a
comma delimiter from passing.