### PR TITLE
Fix special flags enum

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ doc-html/
 
 # Tests
 tests/jpr_test
+tests/api_test
 tests/json_test
 tests/unescape
 tests/cxxtest

--- a/MANIFEST
+++ b/MANIFEST
@@ -17,5 +17,6 @@ perf/perftest.c
 srcutil/genchartables.pl
 tests/Makefile
 tests/jpr_test.c
+tests/api_test.c
 tests/json_test.c
 tests/unescape.c

--- a/jsonsl.h
+++ b/jsonsl.h
@@ -161,12 +161,12 @@ typedef enum {
 #undef X
     /* Handy flags for checking */
 
-    JSONSL_SPECIALf_UNKNOWN = 1 << 8,
+    JSONSL_SPECIALf_UNKNOWN = 1 << 10,
 
     /** @private Private */
-    JSONSL_SPECIALf_ZERO    = 1 << 9 | JSONSL_SPECIALf_UNSIGNED,
+    JSONSL_SPECIALf_ZERO    = 1 << 11 | JSONSL_SPECIALf_UNSIGNED,
     /** @private */
-    JSONSL_SPECIALf_DASH    = 1 << 10,
+    JSONSL_SPECIALf_DASH    = 1 << 12,
     /** @private */
     JSONSL_SPECIALf_POS_INF = (JSONSL_SPECIALf_INF),
     JSONSL_SPECIALf_NEG_INF = (JSONSL_SPECIALf_INF|JSONSL_SPECIALf_SIGNED),

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,6 +4,9 @@ TARGET_LINK_LIBRARIES(json_test jsonsl)
 ADD_EXECUTABLE(failure_test fail-tests.c)
 TARGET_LINK_LIBRARIES(failure_test jsonsl)
 
+ADD_EXECUTABLE(api_test api_test.c)
+TARGET_LINK_LIBRARIES(api_test jsonsl)
+
 ADD_EXECUTABLE(jpr_test jpr_test.c)
 TARGET_LINK_LIBRARIES(jpr_test jsonsl)
 ADD_EXECUTABLE(unescape unescape.c)
@@ -18,6 +21,7 @@ FILE(GLOB samples_ok ${CMAKE_BINARY_DIR}/share/*
 FILE(GLOB samples_bad ${CMAKE_BINARY_DIR}/share/jsc/fail*.json)
 ADD_TEST(okparse json_test ${samples_ok})
 ADD_TEST(badparse failure_test ${samples_bad})
+ADD_TEST(apitest api_test)
 ADD_TEST(jsonpointer jpr_test)
 ADD_TEST(unescape unescape)
 ADD_TEST(cxxtest cxxtest)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,7 +1,8 @@
-TESTMODS= json_test jpr_test unescape cxxtest
+TESTMODS= json_test api_test jpr_test unescape cxxtest
 
 all: $(TESTMODS)
 	./json_test ../share/*
+	./api_test
 	./jpr_test
 	./unescape
 	./json_test ../share/jsc/pass*.json

--- a/tests/api_test.c
+++ b/tests/api_test.c
@@ -1,0 +1,81 @@
+#include "jsonsl.h"
+#include <stdio.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <assert.h>
+#include <errno.h>
+#include "all-tests.h"
+
+
+/* "actual" must have at least all the same bits set as "expected" */
+static void
+check_flags (int actual, int expected)
+{
+    int i;
+
+    for (i = 0; i < (int)(sizeof actual); i++) {
+        if (expected & (1 << i)) {
+            if (!(actual & (1 << i))) {
+                fprintf(stderr, "bit %d not set in special_flags\n", i);
+                abort();
+            }
+        }
+    }
+}
+
+
+static void
+special_flags_test_pop_callback (jsonsl_t jsn,
+                                 jsonsl_action_t action,
+                                 struct jsonsl_state_st *state,
+                                 const char *buf)
+{
+    jsonsl_special_t flags = (jsonsl_special_t) jsn->data;
+    if (state->type == JSONSL_T_SPECIAL) {
+        check_flags (state->special_flags, flags);
+    }
+}
+
+
+int
+main (int argc, char **argv)
+{
+    typedef struct {
+       const char *value;
+       jsonsl_special_t expected_special_flags;
+    } special_flags_test_t;
+
+    special_flags_test_t tests[] = {
+       { "1", JSONSL_SPECIALf_UNSIGNED },
+       { "1.0", JSONSL_SPECIALf_FLOAT|JSONSL_SPECIALf_UNSIGNED },
+       { "0", JSONSL_SPECIALf_UNSIGNED },
+       { "0.0", JSONSL_SPECIALf_FLOAT|JSONSL_SPECIALf_UNSIGNED },
+       { "-0.0", JSONSL_SPECIALf_FLOAT|JSONSL_SPECIALf_SIGNED },
+       { NULL }
+    };
+
+    special_flags_test_t *test;
+    jsonsl_t jsn;
+    char name[512];
+    char formatted_json[512];
+    int formatted_len;
+
+    for (test = tests; test->value; test++) {
+        snprintf (name, sizeof name, "parse \"%s\"", test->value);
+        fprintf (stderr, "==== %-40s ====\n", name);
+        formatted_len = snprintf (formatted_json,
+                                  sizeof formatted_json,
+                                  "{\"x\": %s}",
+                                  test->value);
+
+        jsn = jsonsl_new(0x2000);
+        jsn->data = (void *) test->expected_special_flags;
+        jsn->action_callback_POP = special_flags_test_pop_callback;
+        jsonsl_enable_all_callbacks (jsn);
+
+        jsonsl_feed (jsn, formatted_json, (size_t) formatted_len);
+        jsonsl_destroy (jsn);
+    }
+
+    return 0;
+}


### PR DESCRIPTION
I accidentally allowed overlapping enum values in #6977d68. One symptom
is that parsing "-0.0" sets only the JSONSL_SPECIALf_UNSIGNED flag, not
JSONSL_SPECIALf_FLOAT|JSONSL_SPECIALf_SIGNED as it should.