### PR TITLE
Unnecessary check in jsonsl_util_unescape_ex

### DIFF
--- a/jsonsl.c
+++ b/jsonsl.c
@@ -1413,7 +1413,7 @@ size_t jsonsl_util_unescape_ex(const char *in,
             *oflags |= JSONSL_SPECIALf_NONASCII;
             out = jsonsl__writeutf8(uescval, out) - 1;
 
-        } else if (uescval > 0xD7FF && uescval < 0xDC00) {
+        } else if (uescval < 0xDC00) {
             *oflags |= JSONSL_SPECIALf_NONASCII;
             last_codepoint = (uint16_t)uescval;
             out--;


### PR DESCRIPTION
Found by a Coverity scan. The Coverity analysis is:
```
    	cond_between: Condition uescval > 0xDFFF, taking false branch. Now the value of uescval is between 0xD800 and 0xDFFF.
    	cond_at_least: Condition uescval < 0xD800, taking false branch. Now the value of uescval is at least 0xD800.
1414        } else if (uescval < 0xD800 || uescval > 0xDFFF) {
1415            *oflags |= JSONSL_SPECIALf_NONASCII;
1416            out = jsonsl__writeutf8(uescval, out) - 1;
1417
      dead_error_condition: The condition uescval > 0xD7FF must be true.
    	At condition uescval > 0xD7FF, the value of uescval must be between 0xD800 and 0xDFFF.
1418        } else if (uescval > 0xD7FF && uescval < 0xDC00) {
1419            *oflags |= JSONSL_SPECIALf_NONASCII;
1420            last_codepoint = (uint16_t)uescval;
1421            out--;
1422        } else {
1423            UNESCAPE_BAIL(INVALID_CODEPOINT, 2);
1424        }
```