### PR TITLE
Add fuzzing by way of ClusterFuzzLite

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,0 +1,6 @@
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install -y make autoconf automake libtool
+
+COPY . $SRC/jsonsl
+COPY .clusterfuzzlite/build.sh $SRC/build.sh
+WORKDIR $SRC/jsonsl

--- a/.clusterfuzzlite/README.md
+++ b/.clusterfuzzlite/README.md
@@ -1,0 +1,18 @@
+# ClusterFuzzLite set up
+This folder contains a fuzzing set for [ClusterFuzzLite](https://google.github.io/clusterfuzzlite).
+
+## Reproduce locally
+
+If you'd like to test this the way ClusterFuzzLite runs it (by way of [OSS-Fuzz](https://github.com/google/oss-fuzz)) you can use the steps:
+
+```sh
+git clone https://github.com/google/oss-fuzz
+git clone https://github.com/mnunberg/jsonsl jsonsl
+cd jsonsl
+
+# Build the fuzzers in .clusterfuzzlite
+python3 ../oss-fuzz/infra/helper.py build_fuzzers --external $PWD
+
+# Run the fuzzer for 180 seconds
+python3 ../oss-fuzz/infra/helper.py run_fuzzer --external $PWD parse_fuzzer -- -max_total_time=180
+```

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -eu
+# Supply build instructions
+# Use the following environment variables to build the code
+# $CXX:               c++ compiler
+# $CC:                c compiler
+# CFLAGS:             compiler flags for C files
+# CXXFLAGS:           compiler flags for CPP files
+# LIB_FUZZING_ENGINE: linker flag for fuzzing harnesses
+
+mkdir build
+cd build
+cmake ../
+make
+
+# Copy all fuzzer executables to $OUT/
+$CC $CFLAGS $LIB_FUZZING_ENGINE \
+  $SRC/jsonsl/.clusterfuzzlite/parse_fuzzer.c \
+  -o $OUT/parse_fuzzer \
+  -I$SRC/jsonsl $PWD/libjsonsl.a

--- a/.clusterfuzzlite/parse_fuzzer.c
+++ b/.clusterfuzzlite/parse_fuzzer.c
@@ -1,0 +1,36 @@
+#include <stdint.h>
+#include <jsonsl.h>
+
+
+void state_callback(jsonsl_t jsn,
+                   jsonsl_action_t action,
+                   struct jsonsl_state_st *state,
+                   const char *buf)
+{
+
+}
+
+
+int error_callback(jsonsl_t jsn,
+                   jsonsl_error_t err,
+                   struct jsonsl_state_st *state,
+                   char *errat)
+{
+    return 0;
+}
+
+
+int 
+LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+    jsonsl_t jsn;
+
+    jsn = jsonsl_new(0x100);
+    jsn->error_callback = error_callback;
+    jsn->action_callback = state_callback;
+
+    jsonsl_feed(jsn, (const char*)data, size);
+    jsonsl_destroy(jsn);
+
+    return 0;
+}

--- a/.clusterfuzzlite/project.yaml
+++ b/.clusterfuzzlite/project.yaml
@@ -1,0 +1,1 @@
+language: c

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -1,0 +1,30 @@
+name: ClusterFuzzLite PR fuzzing
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [ main ]
+permissions: read-all
+jobs:
+  PR:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer: [address]
+    steps:
+    - name: Build Fuzzers (${{ matrix.sanitizer }})
+      id: build
+      uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+      with:
+        sanitizer: ${{ matrix.sanitizer }}
+        language: c
+        bad-build-check: false
+    - name: Run Fuzzers (${{ matrix.sanitizer }})
+      id: run
+      uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        fuzz-seconds: 100
+        mode: 'code-change'
+        report-unreproducible-crashes: false
+        sanitizer: ${{ matrix.sanitizer }}


### PR DESCRIPTION
This adds fuzzing by way of [ClusterFuzzLite](https://google.github.io/clusterfuzzlite/), which is a GitHub action that will perform a short amount of fuzzing for new PRs. The goal is to use fuzzing to catch bugs that may be introduced by new PRs.

I added a fuzzer that targets `jsonsl_feed`, and currently set the timeout of CFLite to 100 seconds. CFLite will flag if the fuzzer finds  any issues in the code introduced by a PR.

I added instructions in the `README.md` on how to run the fuzzer locally (notice you'd have to adjust the repos until this PR is merged).